### PR TITLE
Change document id to user email

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,7 +18,7 @@ export const newSignUp = functions.auth.user().onCreate((user) => {
     photoURL: user.photoURL,
     name: user.displayName,
   };
-  return admin.firestore().doc(`userSignUps/${data.name}`).set(data);
+  return admin.firestore().doc(`userSignUps/${data.email}`).set(data);
 });
 
 export const deleteAccount = functions.auth.user().onDelete((user) => {
@@ -29,7 +29,7 @@ export const deleteAccount = functions.auth.user().onDelete((user) => {
     name: user.displayName,
     isDeleted: true,
   };
-  return admin.firestore().doc(`userSignUps/${data.name}`).set(data);
+  return admin.firestore().doc(`userSignUps/${data.email}`).set(data);
 });
 
 // Hello!


### PR DESCRIPTION
Changing the document id to the user's email id, rather than using the user's name, so that 2 or more users with the same name won't throw an error from Cloud Functions.